### PR TITLE
Fixed a bug where ``self.logger`` wouldn't be available in manual use.

### DIFF
--- a/statsd/timer.py
+++ b/statsd/timer.py
@@ -15,7 +15,7 @@ class Timer(statsd.Client):
     '''
 
     def __init__(self, name, connection=None):
-        statsd.Client.__init__(self, name, connection=connection)
+        super(Timer, self).__init__(name, connection=connection)
         self._start = None
         self._last = None
         self._stop = None


### PR DESCRIPTION
In trying to manually use the following code:

```
timer = statsd.Timer(slug, connection=conn)
timer.send('total', seconds_taken)
```

...it would blow up with the exception `AttributeError: 'Timer' object has no attribute 'logger'`. This commit fixes that.
