### PR TITLE
Pull request -- fix for Timer.decorate

### DIFF
--- a/statsd/timer.py
+++ b/statsd/timer.py
@@ -71,7 +71,7 @@ class Timer(statsd.Client):
                 return function(*args, **kwargs)
             finally:
                 # Stop the timer, send the message and cleanup
-                timer.stop(name)
+                timer.stop()
                 del timer
 
         return _decorator


### PR DESCRIPTION
Without this, timing a function as follows

```
@timer.decorate
def my_function():
    do_something()
```

would send timing information as `'application_name.my_function.my_function'`. With the fix, timer is named `'application_name.my_function.total'`, as expected.
