### PR TITLE
Change raw metric message to match format expected by StatsD

### DIFF
--- a/statsd/raw.py
+++ b/statsd/raw.py
@@ -27,5 +27,5 @@ class Raw(statsd.Client):
             ts = timestamp
         name = self._get_name(self.name, subname)
         self.logger.info('%s: %s %s' % (name, value, ts))
-        return statsd.Client._send(self, {name: '%s %s|r' % (value, ts)})
+        return statsd.Client._send(self, {name: '%s|r|%s' % (value, ts)})
 


### PR DESCRIPTION
Send raw messages as "name:value|r|timestamp".  This is compatible with
https://github.com/jeffminard-ck/statsd/tree/raw_and_averages, currently
pending a pull request into https://github.com/etsy/statsd.  This format is also more consistent with other Etsy statsd message formats.
