### PR TITLE
Remove lingering print call

### DIFF
--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -92,8 +92,6 @@ class TestTimerContextManager(TestCase):
         with timer.time():
             pass
 
-        print mock_client._send.call_args[0][1]
-
         assert self.get_time(mock_client, 'cm.default') == 123.4, \
             'This test must execute within 2ms'
 


### PR DESCRIPTION
So it looks like the test error was an actual error; I forgot to remove a print statement, which was erroring on python3 due to print becoming a function.
