### PR TITLE
Fix for sending 0ms entries.

### DIFF
--- a/statsd/timer.py
+++ b/statsd/timer.py
@@ -37,9 +37,13 @@ class Timer(statsd.Client):
         :keyword delta: The time delta (time.time() - time.time()) to report
         '''
         ms = delta * 1000
-        name = self._get_name(self.name, subname)
-        self.logger.info('%s: %0.08fms', name, ms)
-        return statsd.Client._send(self, {name: '%0.08f|ms' % ms})
+        
+        if ms > 0:
+            name = self._get_name(self.name, subname)
+            self.logger.info('%s: %0.08fms', name, ms)
+            return statsd.Client._send(self, {name: '%0.08f|ms' % ms})
+        else:
+            return True
 
     def intermediate(self, subname):
         '''Send the time that has passed since our last measurement


### PR DESCRIPTION
DEBUG: Bad line: 0,ms in msg "production.timer:0|ms"
https://github.com/etsy/statsd/blob/5b900711191a9c5cfd536c877a3c119d1df5679a/lib/helpers.js
Line 35: return isNumber(fields[0]) && Number(fields[0]) > 0;

statsD expects a > 0 number for ms counters.
