### PR TITLE
Extend travis-ci tests with Python 3.4 and pypy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: python
+
 python:
     - "2.6"
     - "2.7"
     - "3.3"
+    - "3.4"
+    - "pypy"
+    - "pypy3"
 
 # command to install dependencies
 install:

--- a/statsd/client.py
+++ b/statsd/client.py
@@ -117,4 +117,3 @@ class Client(object):
 
     def _send(self, data):
         return self.connection.send(data)
-

--- a/statsd/connection.py
+++ b/statsd/connection.py
@@ -80,6 +80,12 @@ class Connection(object):
             self.logger.exception('unexpected error %r while sending data', e)
             return False
 
+    def __del__(self):
+        '''
+        We close UDP socket connection explicitly for pypy.
+        '''
+        self.udp_sock.close()
+
     def __repr__(self):
         return '<%s[%s:%d] P(%.1f)>' % (
             self.__class__.__name__,

--- a/statsd/timer.py
+++ b/statsd/timer.py
@@ -96,7 +96,6 @@ class Timer(statsd.Client):
             finally:
                 # Stop the timer, send the message and cleanup
                 timer.stop('')
-                del timer
 
         return _decorator
 


### PR DESCRIPTION
I know it's not changing a lot but finally we should start supporting 3.4 version - Travis currently uses bugfixed [3.4.1 version](http://blog.travis-ci.com/2014-07-24-upcoming-build-environment-updates/).
