### PR TITLE
Sending gauges with negative values

### DIFF
--- a/statsd/gauge.py
+++ b/statsd/gauge.py
@@ -96,3 +96,30 @@ class Gauge(statsd.Client):
         '''
         self.decrement(delta=delta)
         return self
+
+    def set(self, subname, value):
+        '''Set the data ignoring the sign, ie set("test", -1) will
+         set "test" exactly to -1 (not decrement it by 1)
+        
+        See
+        https://github.com/etsy/statsd/blob/master/docs/metric_types.md
+        "Adding a sign to the gauge value will change the value, rather
+         than setting it.
+                gaugor:-10|g
+                gaugor:+4|g
+        So if gaugor was 333, those commands would set it to 333 - 10 + 4,
+         or 327.
+        Note:
+        This implies you can't explicitly set a gauge to a negative number
+         without first setting it to zero."
+
+        :keyword subname: The subname to report the data to (appended to the
+            client name)
+        :type subname: str
+        :keyword value: The new gauge value
+        '''
+
+        assert isinstance(value, compat.NUM_TYPES)
+        if value < 0:
+            self._send(subname, 0)
+        return self._send(subname, value)

--- a/tests/test_gauge.py
+++ b/tests/test_gauge.py
@@ -24,3 +24,12 @@ class TestGauge(TestCase):
         with mock.patch('statsd.Client') as mock_client:
             self.gauge.send('', 1)
             mock_client._send.assert_called_with(mock.ANY, {'testing': '1|g'})
+
+    def test_set(self):
+        with mock.patch('statsd.Client') as mock_client:
+            self.gauge.set('', -1)
+            mock_client._send.assert_any_call(mock.ANY, {'testing': '0|g'})
+            mock_client._send.assert_any_call(mock.ANY, {'testing': '-1|g'})
+            mock_client.reset_mock()
+            self.gauge.set('', 1)
+            mock_client._send.assert_called_with(mock.ANY, {'testing': '1|g'})


### PR DESCRIPTION
Hi and thanks for this project 

There is a bit of a [pitfail](https://github.com/etsy/statsd/blob/master/docs/metric_types.md#gauges) with gauges in statsd: if you send a number with a sign (any sign), statsd will add/subtract the value instead of setting it. Say, if you send a metric with "-1" over time, graphite (or whatever is that that your statsd is configured to work with) will draw a downward trend, which isn't expected/intuitive behaviour at all. The user is going to have to go and find this special case in the statsd docs. I propose that a new method will be added to statsd.Gauge to set the metric value no matter the sign. What do you think?