### PR TITLE
timer decorator preserves inner function metadata

### DIFF
--- a/statsd/timer.py
+++ b/statsd/timer.py
@@ -1,5 +1,7 @@
 import contextlib
 import time
+from functools import wraps
+
 import statsd
 
 
@@ -88,6 +90,7 @@ class Timer(statsd.Client):
     def _decorate(self, name, function, class_=None):
         class_ = class_ or Timer
 
+        @wraps(function)
         def _decorator(*args, **kwargs):
             timer = self.get_client(name, class_)
             timer.start()

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -51,6 +51,7 @@ class TestTimerDecorator(TestTimerBase):
 
         assert self.get_time(mock_client, 'timer.spam') == 123.4, \
             'This test must execute within 2ms'
+        assert a.__name__ == 'a'
 
     @mock.patch('statsd.Client')
     def test_nested_naming_decorator(self, mock_client):


### PR DESCRIPTION
Make use of `functools.wraps` to keep the decorated function name and docstring. Otherwise our views decorated with the `timer` show up as `statsd.timer:_decorator`